### PR TITLE
Global search buffer with BTree instead of Iterator

### DIFF
--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod unicode {
 pub fn find_first_non_whitespace_char(line: RopeSlice) -> Option<usize> {
     line.chars().position(|ch| !ch.is_whitespace())
 }
+mod rope_reader;
 
 /// Find project root.
 ///
@@ -85,6 +86,7 @@ pub fn find_root(root: Option<&str>, root_markers: &[String]) -> std::path::Path
     top_marker.map_or(current_dir, |a| a.to_path_buf())
 }
 
+pub use rope_reader::RopeReader;
 pub use ropey::{self, str_utils, Rope, RopeBuilder, RopeSlice};
 
 // pub use tendril::StrTendril as Tendril;

--- a/helix-core/src/rope_reader.rs
+++ b/helix-core/src/rope_reader.rs
@@ -1,0 +1,37 @@
+use std::io;
+
+use ropey::iter::Chunks;
+use ropey::RopeSlice;
+
+pub struct RopeReader<'a> {
+    current_chunk: &'a [u8],
+    chunks: Chunks<'a>,
+}
+
+impl<'a> RopeReader<'a> {
+    pub fn new(rope: RopeSlice<'a>) -> RopeReader<'a> {
+        RopeReader {
+            current_chunk: &[],
+            chunks: rope.chunks(),
+        }
+    }
+}
+
+impl io::Read for RopeReader<'_> {
+    fn read(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
+        let buf_len = buf.len();
+        loop {
+            let read_bytes = self.current_chunk.read(buf)?;
+            buf = &mut buf[read_bytes..];
+            if buf.is_empty() {
+                return Ok(buf_len);
+            }
+
+            if let Some(next_chunk) = self.chunks.next() {
+                self.current_chunk = next_chunk.as_bytes();
+            } else {
+                return Ok(buf_len - buf.len());
+            }
+        }
+    }
+}

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2003,7 +2003,7 @@ fn global_search(cx: &mut Context) {
                 return;
             }
 
-            let documents = editor.shared_documents();
+            let document_lookup = editor.document_content_lookup();
 
             if let Ok(matcher) = RegexMatcherBuilder::new()
                 .case_smart(smart_case)
@@ -2033,7 +2033,7 @@ fn global_search(cx: &mut Context) {
                         let mut searcher = searcher.clone();
                         let matcher = matcher.clone();
                         let all_matches_sx = all_matches_sx.clone();
-                        let documents = &documents;
+                        let document_lookup = &document_lookup;
                         Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
                             let entry = match entry {
                                 Ok(entry) => entry,
@@ -2053,11 +2053,11 @@ fn global_search(cx: &mut Context) {
 
                                 Ok(true)
                             });
-                            let doc = documents.clone().find(|(doc_path, _)| {
-                                doc_path.map_or(false, |doc_path| doc_path == entry.path())
-                            });
 
-                            let result = if let Some((_, doc)) = doc {
+                            let entry_path = &entry.path();
+                            let doc = document_lookup.get(entry_path);
+
+                            let result = if let Some(doc) = doc {
                                 // there is already a buffer for this file
                                 // search the buffer instead of the file because it's faster
                                 // and captures new edits without requireing a save


### PR DESCRIPTION
Could we benefit from using a BTree instead of a linear iteration each time?